### PR TITLE
add ONENOV validator monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
 | Thanks To                  | Type                                | URL                         | Status |
 | -------------------------- | ----------------------------------- | --------------------------- | ------ |
 | [AXONE](https://axone.xyz) | AXONE Services Status & Update Time | <https://status.axone.xyz/> | ✅     |
+| [ONENOV](https://onenov.xyz) | Validator Monitoring Dashboard | https://dashboard-axone.onenov.xyz | ✅ |
 | [OwlStake](https://owlstake.com) | RPC Scanner | <https://services.owlstake.com/docs/mainnet/axone/public-rpc> | ✅     |
 | [OwlStake](https://owlstake.com) | Decentralization Analytics | <https://services.owlstake.com/docs/mainnet/axone/decentralization> | ✅     |
 | [OwlStake](https://owlstake.com) | Onchain Analytics (Building) | <https://dashboard.owlstake.com/axone> | ✅     |


### PR DESCRIPTION
Added a link to ONENOV's validator monitoring dashboard to the 📊 Dashboards section of the README.md.

URL: https://dashboard-axone.onenov.xyz
Goal: To help the Axone community monitor validator status in real-time through this dashboard.