### PR TITLE
ci(workflows): add sync-articles workflow

### DIFF
--- a/.github/workflows/sync-articles.yml
+++ b/.github/workflows/sync-articles.yml
@@ -1,0 +1,41 @@
+name: Sync articles
+
+on:
+  schedule:
+    - cron: 0 8 * * *
+  workflow_dispatch:
+
+jobs:
+  update-axone-blog-section:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPS_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Update README with latest Axone articles
+        uses: JasonEtco/rss-to-readme@v2
+        with:
+          feed_url: "https://blog.axone.xyz/feed"
+          readme-section: "axone-medium"
+          max: 15
+          template: "- 📝 [{{ title }}]({{ link }}) — {{ pubDate }}"
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_user_name: ${{ vars.BOT_GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ vars.BOT_GIT_COMMITTER_EMAIL }}
+          commit_author: ${{ vars.BOT_GIT_AUTHOR_NAME }} <${{ vars.BOT_GIT_AUTHOR_EMAIL }}>
+          commit_message: "feat(README): update Axone articles section"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@
 | Guide | <https://boygau.top/guide/mainet/axone.html> | ✅ | [BoyGau](https://boygau.top) |
 | Guide | <https://indonode.net/services/mainnet/axone> | ✅ | [Indonode](https://indonode.net/) |
 
+## 📖 Axone blog
+
+<!--START_SECTION:axone-medium-->
+<!--END_SECTION:axone-medium-->
+
 ## 🔭 Block Explorers
 
 | Thanks To                                | Explorer | URL                                           | Status |


### PR DESCRIPTION
Just because the [Axone blog](https://blog.axone.xyz) belongs here, let’s auto-sync its content using [`rss-to-readme`](https://github.com/JasonEtco/rss-to-readme) action to slurp the RSS feed like it’s meant to be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new section in the README to display the latest Axone blog articles.
  * Introduced an automated process that updates this section daily with the 15 most recent articles from the Axone blog.

* **Chores**
  * Set up a scheduled workflow to keep the README's blog section up to date automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->