### PR TITLE
ci(workflows): replace rss-to-readme with inline Python parser

### DIFF
--- a/.github/workflows/sync-articles.yml
+++ b/.github/workflows/sync-articles.yml
@@ -25,8 +25,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Install dependencies
-        run: pip install feedparser
-
+        run: python -m pip install feedparser==6.0.10
       - name: Update Axone articles section
         shell: python
         run: |

--- a/.github/workflows/sync-articles.yml
+++ b/.github/workflows/sync-articles.yml
@@ -24,13 +24,44 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Update README with latest Axone articles
-        uses: JasonEtco/rss-to-readme@v2
-        with:
-          feed-url: "https://blog.axone.xyz/feed"
-          readme-section: "axone-medium"
-          max: 15
-          template: "- 📝 [{{ title }}]({{ link }}) — {{ pubDate }}"
+      - name: Install dependencies
+        run: pip install feedparser
+
+      - name: Update Axone articles section
+        shell: python
+        run: |
+          import feedparser
+          import re
+          import sys
+
+          README = "README.md"
+          FEED_URL = "https://blog.axone.xyz/feed"
+          START = "<!--START_SECTION:axone-medium-->"
+          END = "<!--END_SECTION:axone-medium-->"
+          MAX_ITEMS = 10
+
+          feed = feedparser.parse(FEED_URL)
+
+          lines = []
+          for entry in feed.entries[:MAX_ITEMS]:
+              title = getattr(entry, "title", "").strip()
+              link = getattr(entry, "link", "").strip()
+              pub = getattr(entry, "published", "").strip()
+              if title and link:
+                  lines.append(f"- 📝 [{title}]({link}) — {pub}")
+
+          with open(README, "r", encoding="utf-8") as f:
+              content = f.read()
+
+          pattern = re.compile(f"{re.escape(START)}.*?{re.escape(END)}", re.DOTALL)
+          if not pattern.search(content):
+              sys.exit("Start or end marker not found in README.md")
+
+          new_block = f"{START}\n" + "\n".join(lines) + f"\n{END}"
+          updated = pattern.sub(new_block, content)
+
+          with open(README, "w", encoding="utf-8") as f:
+              f.write(updated)
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@
 ## 📖 Axone blog
 
 <!--START_SECTION:axone-medium-->
+- 📝 [The Power of Machines, the Duty of Humans](https://blog.axone.xyz/the-power-of-machines-the-duty-of-humans-8d9e664ce3d1?source=rss----9225d63e3e85---4) — Wed, 06 Aug 2025 06:16:53 GMT
+- 📝 [Announcing Genesis Delegation Program Results](https://blog.axone.xyz/announcing-genesis-delegation-program-results-063129353d6f?source=rss----9225d63e3e85---4) — Tue, 05 Aug 2025 08:35:49 GMT
+- 📝 [From HR to AR: Why the Future Needs Agent Resource Management?](https://blog.axone.xyz/from-hr-to-ar-why-the-future-needs-agent-resource-management-e51e6e398013?source=rss----9225d63e3e85---4) — Fri, 25 Jul 2025 14:13:33 GMT
+- 📝 [Of Agents and Meaning: Building Collaborative AI in the Post-Web Era](https://blog.axone.xyz/of-agents-and-meaning-building-collaborative-ai-in-the-post-web-era-4defee9fb836?source=rss----9225d63e3e85---4) — Tue, 22 Jul 2025 13:30:42 GMT
+- 📝 [Unlocking Decentralization: Inside Axone’s Delegation Initiatives](https://blog.axone.xyz/unlocking-decentralization-inside-axones-delegation-initiatives-92b9e3eeca0c?source=rss----9225d63e3e85---4) — Mon, 21 Jul 2025 10:15:55 GMT
+- 📝 [Mainnet is Live: Tokenomics Breakdown and Next Steps](https://blog.axone.xyz/mainnet-is-live-tokenomics-breakdown-and-next-steps-e342071c12e9?source=rss----9225d63e3e85---4) — Fri, 18 Jul 2025 12:06:24 GMT
+- 📝 [Of Angels and Agents: Towards a Semantic Internet of Action](https://blog.axone.xyz/of-angels-and-agents-towards-a-semantic-internet-of-action-9f1ae5432157?source=rss----9225d63e3e85---4) — Sat, 12 Jul 2025 11:04:02 GMT
+- 📝 [We’re Not Launching a Blockchain. We’re Launching a Protocol.](https://blog.axone.xyz/were-not-launching-a-blockchain-we-re-launching-a-protocol-87ea692bd3b8?source=rss----9225d63e3e85---4) — Sat, 05 Jul 2025 08:46:56 GMT
+- 📝 [Axone Tokenomics: Building Value Beyond Hype](https://blog.axone.xyz/axone-tokenomics-building-value-beyond-hype-982ccd048ce1?source=rss----9225d63e3e85---4) — Tue, 01 Jul 2025 10:52:34 GMT
+- 📝 [Axone Mainnet Launches July 8! — But why the $AXONE token won’t be tradable at launch](https://blog.axone.xyz/axone-mainnet-launches-july-8-but-why-the-axone-token-wont-be-tradable-at-launch-066ef652882d?source=rss----9225d63e3e85---4) — Wed, 25 Jun 2025 08:59:38 GMT
 <!--END_SECTION:axone-medium-->
 
 ## 🔭 Block Explorers


### PR DESCRIPTION
Replaced [rss-to-readme](https://github.com/JasonEtco/rss-to-readme) action introduced with #48 with an inline minimal Python code - action was doing its own commit & push, which made things hard to control.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the process for updating the Axone blog articles section in the README.
* **Documentation**
  * Refreshed the "📖 Axone blog" section in the README with the latest ten articles, including titles, links, and publication dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->