### PR TITLE
Add new link guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | Whitepaper | <https://docs.axone.xyz/whitepaper/abstract>                           | ✅     | [AXONE](https://axone.xyz)               |
 | Guide     | <https://nodesync.top/services/mainnet/axone/installation>               | ✅     | [NODESYNC](https://nodesync.top)         |
 | Guide     | <https://luckystar-1.gitbook.io/luckystar.asia/mainnet/cosmos-eco/axone> | ✅     | [LuckyStar](https://www.luckystar.asia/) |
-| Guide | <https://onenov-docs.onenov.xyz/tutorial/axone-mainnet> | ✅     | [OneNov](https://onenov.xyz) |
+| Guide | <https://www.onenov.xyz/validator/axone> | ✅     | [OneNov](https://onenov.xyz) |
 | Guide | <https://node39.top/docs/Mainnet/Axone/Installation> | ✅     | [Node39.TOP](https://node39.top) |
 | Guide      | <https://dnsarz.xyz/services/mainnet/axone/> | ✅    | [dnsarz](https://dnsarz.xyz) |
 | Guides    | <https://services.shazoes.xyz/mainnets/axone/node-installation> | ✅     | [Shazoes](https://services.shazoes.xyz) |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | Whitepaper | <https://docs.axone.xyz/whitepaper/abstract>                           | ✅     | [AXONE](https://axone.xyz)               |
 | Guide     | <https://nodesync.top/services/mainnet/axone/installation>               | ✅     | [NODESYNC](https://nodesync.top)         |
 | Guide     | <https://luckystar-1.gitbook.io/luckystar.asia/mainnet/cosmos-eco/axone> | ✅     | [LuckyStar](https://www.luckystar.asia/) |
-| Guide | <https://www.onenov.xyz/axone.html> | ✅     | [OneNov](https://onenov.xyz) |
+| Guide | <https://onenov-docs.onenov.xyz/tutorial/axone-mainnet> | ✅     | [OneNov](https://onenov.xyz) |
 | Guide | <https://node39.top/docs/Mainnet/Axone/Installation> | ✅     | [Node39.TOP](https://node39.top) |
 | Guide      | <https://dnsarz.xyz/services/mainnet/axone/> | ✅    | [dnsarz](https://dnsarz.xyz) |
 | Guides    | <https://services.shazoes.xyz/mainnets/axone/node-installation> | ✅     | [Shazoes](https://services.shazoes.xyz) |

--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@
 | Thanks To                  | Type                                | URL                         | Status |
 | -------------------------- | ----------------------------------- | --------------------------- | ------ |
 | [AXONE](https://axone.xyz) | AXONE Services Status & Update Time | <https://status.axone.xyz/> | ✅     |
-| [ONENOV](https://onenov.xyz) | Validator Monitoring Dashboard | https://dashboard-axone.onenov.xyz | ✅ |
 | [OwlStake](https://owlstake.com) | RPC Scanner | <https://services.owlstake.com/docs/mainnet/axone/public-rpc> | ✅     |
 | [OwlStake](https://owlstake.com) | Decentralization Analytics | <https://services.owlstake.com/docs/mainnet/axone/decentralization> | ✅     |
 | [OwlStake](https://owlstake.com) | Onchain Analytics (Building) | <https://dashboard.owlstake.com/axone> | ✅     |
 | [catsmile](https://www.catsmile.cloud/)  | Monitoring Validator | <https://monitor-pro.catsmile.cloud/> | ✅     |
+| [ONENOV](https://onenov.xyz) | Validator Monitoring Dashboard | https://dashboard-axone.onenov.xyz | ✅ |
 
 ## 🖥️ Applications
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
 | Thanks To                  | Type                                | URL                         | Status |
 | -------------------------- | ----------------------------------- | --------------------------- | ------ |
 | [AXONE](https://axone.xyz) | AXONE Services Status & Update Time | <https://status.axone.xyz/> | ✅     |
+| [ONENOV](https://onenov.xyz) | Validator Monitoring Dashboard | https://dashboard-axone.onenov.xyz | ✅ |
 | [OwlStake](https://owlstake.com) | RPC Scanner | <https://services.owlstake.com/docs/mainnet/axone/public-rpc> | ✅     |
 | [OwlStake](https://owlstake.com) | Decentralization Analytics | <https://services.owlstake.com/docs/mainnet/axone/decentralization> | ✅     |
 | [OwlStake](https://owlstake.com) | Onchain Analytics (Building) | <https://dashboard.owlstake.com/axone> | ✅     |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the README to point the OneNov guide link to the current Axone validator page, replacing an outdated URL.
  - Improves navigation and ensures users access the most up-to-date validator instructions.
  - Link label and status remain unchanged; no functional or behavioral impact on the application.
  - No changes to public APIs or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->